### PR TITLE
Optimize cart count logic and remove JS duplication

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -10,18 +10,6 @@ function refreshCartCount(){
 }
 document.addEventListener('DOMContentLoaded', refreshCartCount);
 
-function post(url,data){return fetch(url,{method:'POST',body:data}).then(r=>r.json())}
-function addToCart(pid, qty=1){
-  const fd = new FormData(); fd.append('product_id', pid); fd.append('qty', qty);
-  post('cart_add.php', fd).then(r=>{ alert(r.message||'কার্টে যোগ হয়েছে'); refreshCartCount(); });
-}
-function refreshCartCount(){
-  fetch('cart_count.php').then(r=>r.json()).then(r=>{
-    const el = document.querySelector('#cartCount'); if(el) el.textContent = r.count;
-  });
-}
-document.addEventListener('DOMContentLoaded', refreshCartCount);
-
 // ---- Search Auto-suggest ----
 (function(){
   const input  = document.getElementById('searchInput');

--- a/cart_add.php
+++ b/cart_add.php
@@ -18,7 +18,7 @@ try {
   if (!isset($_SESSION['cart']) || !is_array($_SESSION['cart'])) { $_SESSION['cart'] = []; }
   $_SESSION['cart'][$pid] = ($_SESSION['cart'][$pid] ?? 0) + $qty;
 
-  $count = 0; foreach ($_SESSION['cart'] as $q) { $count += (int)$q; }
+  $count = cart_count();
 
   echo json_encode(['ok'=>true,'message'=>'কার্টে যোগ হয়েছে','count'=>$count]);
 } catch (Throwable $e) {

--- a/cart_count.php
+++ b/cart_count.php
@@ -1,3 +1,4 @@
-<?php require_once __DIR__.'/config.php'; header('Content-Type: application/json');
-$c = 0; if(!empty($_SESSION['cart'])) foreach($_SESSION['cart'] as $q){ $c += (int)$q; }
-echo json_encode(['count'=>$c]);
+<?php
+require_once __DIR__.'/config.php';
+header('Content-Type: application/json');
+echo json_encode(['count' => cart_count()]);

--- a/config.php
+++ b/config.php
@@ -35,6 +35,10 @@ function get_pdo(){
 
 session_start();
 
+function cart_count(){
+  return array_sum(array_map('intval', $_SESSION['cart'] ?? []));
+}
+
 function h($s){ return htmlspecialchars($s ?? '', ENT_QUOTES, 'UTF-8'); }
 function money_bd($n){ return '৳'.number_format((float)$n, 0); }
 function today(){ return date('Y-m-d'); }

--- a/partials_header.php
+++ b/partials_header.php
@@ -195,7 +195,7 @@
       <a class="btn secondary cart-btn" href="<?php echo BASE_URL; ?>/cart.php" aria-label="কার্ট">
         <i class="fa-solid fa-cart-shopping"></i>
         <span class="label">কার্ট</span>
-        <span class="count" id="cartCount">0</span>
+        <span class="count" id="cartCount"><?php echo cart_count(); ?></span>
       </a>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add helper `cart_count()` for efficient cart total calculation
- reuse helper in cart endpoints and header
- remove duplicate code from `assets/app.js`

## Testing
- `php -l config.php`
- `php -l cart_add.php`
- `php -l cart_count.php`
- `php -l partials_header.php`
- `node --check assets/app.js`


------
https://chatgpt.com/codex/tasks/task_b_68aee9780fe08332a12476f700c4c24b