### PR TITLE
Track page views for index and product pages

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -43,6 +43,15 @@ $stm->execute([$td]); $pending_today = (int)$stm->fetchColumn();
 $stm = $pdo->prepare("SELECT COUNT(*) FROM products WHERE stock <= ?");
 $stm->execute([$LOW_STOCK]); $low_stock_count = (int)$stm->fetchColumn();
 
+/* Page view counts */
+$views = [];
+try {
+  $stm = $pdo->query("SELECT page, views FROM page_views WHERE page IN ('index','product')");
+  $views = $stm->fetchAll(PDO::FETCH_KEY_PAIR);
+} catch (Throwable $e) {}
+$index_views   = (int)($views['index']   ?? 0);
+$product_views = (int)($views['product'] ?? 0);
+
 /* ---- Recent orders (today) ---- */
 $limit = 15;
 $stm = $pdo->prepare("SELECT id, order_code, customer_name, mobile, total, status, created_at
@@ -162,6 +171,27 @@ function status_badge_class($s){
         <div>
           <div class="text-muted small">লো-স্টক (≤ <?php echo (int)$LOW_STOCK; ?>)</div>
           <div class="kpi-value"><?php echo $low_stock_count; ?></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Page Views -->
+<div class="card mb-3">
+  <div class="card-body">
+    <h6 class="mb-3">Page Views</h6>
+    <div class="row">
+      <div class="col-12 col-md-6">
+        <div class="d-flex justify-content-between align-items-center">
+          <span>Home (index.php)</span>
+          <span class="fw-bold"><?=$index_views?></span>
+        </div>
+      </div>
+      <div class="col-12 col-md-6">
+        <div class="d-flex justify-content-between align-items-center">
+          <span>Product (product.php)</span>
+          <span class="fw-bold"><?=$product_views?></span>
         </div>
       </div>
     </div>

--- a/config.php
+++ b/config.php
@@ -62,4 +62,18 @@ function save_setting($key, $value){
   $pdo->prepare("INSERT INTO settings(`key`,`value`) VALUES(?,?) ON DUPLICATE KEY UPDATE value=VALUES(value)")
       ->execute([$key, $value]);
 }
+
+// ---------- page view helpers ----------
+function increment_page_view($page){
+  $pdo = get_pdo();
+  $pdo->prepare("INSERT INTO page_views(page, views) VALUES(?,1) ON DUPLICATE KEY UPDATE views=views+1")
+      ->execute([$page]);
+}
+
+function get_page_views($page){
+  $pdo = get_pdo();
+  $stm = $pdo->prepare("SELECT views FROM page_views WHERE page=? LIMIT 1");
+  $stm->execute([$page]);
+  return (int)($stm->fetchColumn() ?: 0);
+}
 ?>

--- a/db.sql
+++ b/db.sql
@@ -110,9 +110,12 @@ CREATE TABLE IF NOT EXISTS `settings` (
   `value` text DEFAULT NULL,
   PRIMARY KEY (`key`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-
-
+-- 8) page_views
+CREATE TABLE IF NOT EXISTS `page_views` (
+  `page` varchar(100) NOT NULL,
+  `views` int(11) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`page`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- data.sql
 -- Inserts only (assumes schema.sql already ran)

--- a/index.php
+++ b/index.php
@@ -1,4 +1,7 @@
-<?php require_once __DIR__.'/config.php'; ?>
+<?php
+require_once __DIR__.'/config.php';
+increment_page_view('index');
+?>
 <?php include __DIR__.'/partials_header.php'; ?>
 
 <?php

--- a/product.php
+++ b/product.php
@@ -14,6 +14,7 @@ $stm = $pdo->prepare("
 $stm->execute([$id]);
 $p = $stm->fetch();
 if (!$p) { http_response_code(404); echo "Not Found"; exit; }
+increment_page_view('product');
 
 /* ---------- Stock flags ---------- */
 $stock     = max(0, (int)($p['stock'] ?? 0));


### PR DESCRIPTION
## Summary
- record visits to index and product pages
- expose page view counts on the admin dashboard
- store view metrics in new `page_views` table

## Testing
- `php -l config.php`
- `php -l index.php`
- `php -l product.php`
- `php -l admin/index.php`


------
https://chatgpt.com/codex/tasks/task_b_68b1271ba7d8833293f957783f9d45d8